### PR TITLE
Add team yaml files

### DIFF
--- a/data/teams/README.md
+++ b/data/teams/README.md
@@ -5,15 +5,24 @@
 Contribute a separate [YAML file](https://yaml.org/) for each entry.
 
 ### YAML schema
-
-Each entry has the following required and optional keys:
+First, populate the people.yml file with any missing people from your team, with the following required and optional keys:
 ```
-name: (required team name)
+lab: (required lab / institution)
 members:
   - name: (required)
     url: (optional)
     twitter: (optional)
     email: (optional)
+  - ...
+
+
+```
+Then, each team entry has the following required and optional keys:
+```
+name: (required team name)
+members:
+  - name: (required)
+    role: (optional)
   - ...
 
 ```

--- a/data/teams/drug_discovery.yml
+++ b/data/teams/drug_discovery.yml
@@ -1,0 +1,11 @@
+name: Drug Discovery
+members:
+  - name: John Chodera
+  - name: Melissa Boby
+    role: Chemical Biology insight
+  - name: Binisha Karki
+    role: Lit Review
+  - name: Chiara Mancinelli
+    role: Lit Review
+  - name: Hannah Bruce Macdonald
+    role: Lit Review; Computational Docking

--- a/data/teams/people.yml
+++ b/data/teams/people.yml
@@ -1,0 +1,25 @@
+lab: Chodera Lab
+members:
+  - name: John Chodera
+    url: http://choderalab.org
+    email: john.chodera@choderalab.org
+    twitter: jchodera
+  - name: Melissa Boby
+    role: Chemical Biology insight
+    url: http://choderalab.org
+    email: melissa.boby@choderalab.org
+  - name: Binisha Karki
+    role: Lit Review
+    url: http://choderalab.org
+    email: binisha.karki@choderalab.org
+  - name: Chiara Mancinelli
+    role: Lit Review
+    url: http://choderalab.org
+    email: chiara.mancinelli@choderalab.org
+  - name: Hannah Bruce Macdonald
+    role: Lit Review; Computational Docking
+    url: http://choderalab.org
+    email: hannah.brucemacdonald@choderalab.org
+  - name: Erica Goldberger
+    url: http://choderalab.org
+    email: erica.goldberger@choderalab.org

--- a/data/teams/structures.yml
+++ b/data/teams/structures.yml
@@ -1,0 +1,8 @@
+name: Structures
+members:
+  - name: Alex Payne
+    role: Lit Review, visualization
+  - name: Hannah Bruce Macdonald
+    role: visualization
+  - name: Erica Goldberger
+    role: Lit Review

--- a/data/teams/targets.yml
+++ b/data/teams/targets.yml
@@ -1,15 +1,6 @@
 name: Targets
 members:
   - name: John Chodera
-    url: http://choderalab.org
-    email: john.chodera@choderalab.org
-    twitter: jchodera
   - name: Alex Payne
-    url: http://choderalab.org
-    email: alex.payne@choderalab.org
   - name: Erica Goldberger
-    url: http://choderalab.org
-    email: erica.goldberger@choderalab.org
   - name: Binisha Karki
-    url: http://choderalab.org
-    email: binisha.karki@choderalab.org

--- a/data/teams/targets.yml
+++ b/data/teams/targets.yml
@@ -10,3 +10,6 @@ members:
   - name: Erica Goldberger
     url: http://choderalab.org
     email: erica.goldberger@choderalab.org
+  - name: Binisha Karki
+    url: http://choderalab.org
+    email: binisha.karki@choderalab.org


### PR DESCRIPTION
## Description
Don't merge yet, just wanted to have a PR for adding the team yaml files.
Have added a "people" file to link info to names (lab, url, etc).
Then the teams are simple, just names and roles.
This is useful because several of us are in multiple teams. Hopefully this will simplify (i.e. each person will just be in charge of a single team) but for now this is a flexible way to do it.

<!---
### This wont show up in your PR, its just info for you ###

Reminder: The folder structure is as follows:

sorted_by_group
└──YOUR_GROUP_NAME
   ├── README.md
   └── TARGET
       ├── algorithms
       ├── analysis
       ├── movies
       ├── papers
       ├── program_specific_structures
       │   └── SIMULATION_SOFTWARE
       ├── simulation_configs
       │   └── SIMULATION_SOFTWARE
       ├── structures
       └── trajectories
       
Please also include any metadata files (e.g. provenance, how-to, etc) 
and additional use instructions for any file you want people to use.

-->

## Status
- [ ] Adheres to the requested folder structure
- [ ] Metadata is provided for each file
- [ ] Ready to go
